### PR TITLE
deploy yaml

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,35 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main, version-2]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install, build, and upload
+        uses: withastro/action@v3
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: Deploy to GitHub Pages
 
 on:
   push:
-    branches: [main, version-2]
+    branches: [main]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for deploying the project to GitHub Pages. The workflow is triggered on pushes to the `main` and `version-2` branches or via manual dispatch, and it defines separate build and deploy jobs.

Deployment automation:

* Added a new workflow file `.github/workflows/deploy.yml` to automate deployment to GitHub Pages, including build and deploy steps using `withastro/action` and `actions/deploy-pages`.
* Configured the workflow to run on pushes to `main` and `version-2` branches, and to allow manual triggering with `workflow_dispatch`.
* Set up appropriate permissions and concurrency settings for safe and efficient deployment.