### PR TITLE
new domain

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -3,7 +3,7 @@ import tailwind from '@astrojs/tailwind';
 import sitemap from '@astrojs/sitemap';
 
 export default defineConfig({
-  site: 'https://galaxylens.art',
+  site: 'https://brookelynhobbs.com',
   integrations: [tailwind(), sitemap()],
   output: 'static',
 });

--- a/public/CNAME
+++ b/public/CNAME
@@ -1,1 +1,1 @@
-galaxylens.art
+brookelynhobbs.com

--- a/src/data/site.ts
+++ b/src/data/site.ts
@@ -1,7 +1,7 @@
 export const site = {
   name: 'Brookelyn McPherson',
   tagline: 'Social Media Managing · Content Creation · Photographer',
-  domain: 'galaxylens.art',
+  domain: 'brookelynhobbs.com',
   email: 'brookelynmcpherson@gmail.com',
   location: 'Greenville, SC',
 


### PR DESCRIPTION
This pull request updates the site configuration and metadata to reflect a new domain and site identity. The main changes involve switching from `galaxylens.art` to `brookelynhobbs.com` across configuration files and site data.

**Domain and Site Identity Update:**

* Updated the `site` property in `astro.config.mjs` to use `https://brookelynhobbs.com` instead of `https://galaxylens.art`.
* Changed the domain in the `public/CNAME` file from `galaxylens.art` to `brookelynhobbs.com` for correct DNS configuration.
* Updated the `domain` field in `src/data/site.ts` to `brookelynhobbs.com`.