### PR TITLE
updated metadata and favicon

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -15,8 +15,11 @@ interface Props {
 const {
   title = `${site.name} — ${site.tagline}`,
   description = `${site.name} — photographer, marketing strategist, and content creator helping brands turn ideas into impactful campaigns.`,
-  ogImage = '/images/camera.png',
+  ogImage = '/images/brooke2.jpeg',
 } = Astro.props;
+
+const canonicalURL = new URL(Astro.url.pathname, Astro.site).toString();
+const ogImageURL = new URL(ogImage, Astro.site).toString();
 ---
 
 <!DOCTYPE html>
@@ -27,10 +30,18 @@ const {
     <meta name="theme-color" content="#4A1B20" />
     <meta name="description" content={description} />
     <meta name="author" content={site.name} />
+    <link rel="canonical" href={canonicalURL} />
     <meta property="og:title" content={title} />
     <meta property="og:description" content={description} />
-    <meta property="og:image" content={ogImage} />
+    <meta property="og:image" content={ogImageURL} />
+    <meta property="og:image:alt" content={`${site.name} portrait`} />
+    <meta property="og:url" content={canonicalURL} />
+    <meta property="og:site_name" content={site.name} />
     <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content={title} />
+    <meta name="twitter:description" content={description} />
+    <meta name="twitter:image" content={ogImageURL} />
     <link rel="icon" href="/images/camera.png" type="image/png" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />


### PR DESCRIPTION
This pull request enhances the SEO and social sharing metadata for the site by updating the Open Graph and Twitter meta tags, as well as improving the canonical URL handling. The main focus is on ensuring that shared links display correct and consistent information across platforms.

SEO and Social Metadata Improvements:

* Changed the default Open Graph image to `/images/brooke2.jpeg` and ensured the `og:image` meta tag uses an absolute URL (`ogImageURL`). [[1]](diffhunk://#diff-621c0d4e1d798274214c5a1d9218138167506a88dcdace8c2bb980d6fb10b08bL18-R22) [[2]](diffhunk://#diff-621c0d4e1d798274214c5a1d9218138167506a88dcdace8c2bb980d6fb10b08bR33-R44)
* Added a canonical URL calculation and included it in the `<link rel="canonical">` and `og:url` meta tag for better SEO. [[1]](diffhunk://#diff-621c0d4e1d798274214c5a1d9218138167506a88dcdace8c2bb980d6fb10b08bL18-R22) [[2]](diffhunk://#diff-621c0d4e1d798274214c5a1d9218138167506a88dcdace8c2bb980d6fb10b08bR33-R44)
* Enhanced Open Graph meta tags by adding `og:image:alt`, `og:site_name`, and ensuring all relevant tags use absolute URLs.
* Added Twitter Card meta tags (`twitter:card`, `twitter:title`, `twitter:description`, `twitter:image`) to improve how links appear when shared on Twitter.